### PR TITLE
Jar filter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -55,7 +55,7 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
-webjars.searchGroupUrl="http://search.maven.org/solrsearch/select?q=g:%22org.webjars%22&core=gav&rows=500&wt=json"
+webjars.searchGroupUrl="http://search.maven.org/solrsearch/select?q=g:%22org.webjars%22%20AND%20p:"jar"&core=gav&rows=500&wt=json"
 webjars.jarUrl="jar:http://search.maven.org/remotecontent?filepath=org/webjars/%s/%s/%s-%s.jar!/"
 
 ehcacheplugin=disabled


### PR DESCRIPTION
Filter only jar type projects e.g. we do not want parent poms. By doing this the following projects are excluded:
- less-parent
- webjars-parent
- webjars-maven-plugin
