### PR TITLE
Update link to Xitrum home page

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -89,8 +89,8 @@ play.Project.playScalaSettings</code></pre>
             <div class="tab-pane" id="xitrum">
                 <h3>Instructions for Xitrum</h3>
 
-                <p><a href="http://xitrum-framework.github.io/xitrum/">Xitrum</a>
-                from 3.13 has <a href="http://xitrum-framework.github.io/xitrum/guide/static.html#serve-resource-files-in-classpath-with-webjars-convention">built-in</a>
+                <p><a href="http://xitrum-framework.github.io/">Xitrum</a>
+                from 3.13 has <a href="http://xitrum-framework.github.io/guide/static.html#serve-resource-files-in-classpath-with-webjars-convention">built-in</a>
                 support for WebJars. If you have a dependency like this:</p>
 
                 <pre><code>libraryDependencies += "org.webjars" % "underscorejs" % "1.6.0-3"</code></pre>


### PR DESCRIPTION
Move Xitrum home page from http://xitrum-framework.github.io/xitrum/ to http://xitrum-framework.github.io/
