### PR TITLE
Fixed JSF documentation (h:outputStylesheet/h:outputScript)

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -179,7 +179,7 @@
 &lt;/dependencies&gt;</code></pre>
                 <br>
                 Then simply reference the resource like:
-                <pre><code>&lt;h:outputStylesheet library="webjars" name="bootstrap/3.1.0/css/bootstrap.min.css" /&gt;</code></pre>
+                <pre><code>&lt;h:outputScript library="webjars" name="bootstrap/3.1.0/css/bootstrap.min.css" /&gt;</code></pre>
             </div>
 
 

--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -179,7 +179,8 @@
 &lt;/dependencies&gt;</code></pre>
                 <br>
                 Then simply reference the resource like:
-                <pre><code>&lt;h:outputScript library="webjars" name="bootstrap/3.1.0/css/bootstrap.min.css" /&gt;</code></pre>
+                <pre><code>&lt;h:outputStylesheet library="webjars" name="bootstrap/3.1.0/css/bootstrap.min.css" /&gt;
+&lt;h:outputScript library="webjars" name="jquery/1.11.2/jquery.js" /&gt;</code></pre>
             </div>
 
 


### PR DESCRIPTION
Tag h:outputStylesheet(old) is used to reference css files. Changed to h:outputScript.