### PR TITLE
Recommend date + commit ID

### DIFF
--- a/app/views/contributing.scala.html
+++ b/app/views/contributing.scala.html
@@ -17,9 +17,9 @@
         </li>
         <li>The version number must only be in the WebJar path, not in files.</li>
         <li>The version number is the upstream version, not the WebJar version.  Most of the time these are the same.  But sometimes there are packaging bugs in a WebJar that cause a version bump in just the WebJar version.</li>
-        <li>The upstream source must be a versioned artifact.  If the upstream source doesn't provide a released version then either use a git commit ID or fork the upstream project and apply semantic versioning.</li>
-        <li>The artifactId should always be lowercased. It can be built from (by order of preference): 
-            <ul>    
+        <li>The upstream source must be a versioned artifact.  If the upstream source doesn't provide a released version then either use a commit date + git commit ID (eg. 20140708-394bf29) or fork the upstream project and apply semantic versioning.</li>
+        <li>The artifactId should always be lowercased. It can be built from (by order of preference):
+            <ul>
                 <li>The name used for bower / npm releases of the library</li>
                 <li>The upstream GitHub repository name of the library</li>
                 <li>The name of the library</li>


### PR DESCRIPTION
I wanted to add a dependency on jslint, which uses the commit ID (as recommended by the webjars.org). But commit IDs make it very difficult to find out what the latest version is when viewed on the command line or in an IDE (Eclipse in the screenshot)

![screenshot from 2015-02-06 14 10 33](https://cloud.githubusercontent.com/assets/58760/6079143/fee5dbf6-ae09-11e4-815f-b2f81d943c83.png)

I suggest using a date (YYYYMMDD) + 7-character commit ID to get a useful ordering.