### PR TITLE
Improve Spring MVC documentation

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -330,8 +330,9 @@ public String webjarjs() {
                 <br>
                 <span class="label label-success">Note</span> The url given to <code>getSetupJavaScript</code> has to be the url given to <code>ResourceHandler</code> and end with a <span>/</span>
                 <br><br>
-                This <code>RequestMapping</code> returns the setup code for your webjars and requirejs. It has to be included in your template before any JavaScript library that uses RequireJS like this:
-                <pre><code>&lt;script data-main="/js/core.js" src="/webjarsjs"&gt;&lt;/script&gt;</code></pre>
+                This <code>RequestMapping</code> returns the setup code for your webjars and requirejs. It has to be included in your template before loading RequireJS. A basic setup looks like this:
+                <pre><code>&lt;script src="/webjarsjs"&gt;&lt;/script&gt;
+&lt;script data-main="/js/app" src="/webjars/requirejs/2.1.16/require.min.js"&gt;&lt;/script&gt;</code></pre>
                 This loads the WebJars RequireJS configuration from <span class="label label-info">webjars-locator</span> and the RequireJS with a main JavaScript of <span class="label label-info">js/app</span>.
                 <br><br>
                 Underneath the covers each WebJar can have a RequireJS configuration file that sets up the modules, shims, exports, etc.  These files is named <span class="label label-info">webjars-requirejs.js</span> and are automatically added to the page via the <code>RequireJS.setup</code> helper.

--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -310,6 +310,24 @@ public class WebConfig extends WebMvcConfigurerAdapter {
                 Then reference a WebJar asset like: 
                 <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/3.1.0/css/bootstrap.min.css'&gt;</code></pre>
                 
+                <h3>Making dependencies version agnostic</h3>
+                By utilizing the <code>webjars-locator</code> library, it is possible to reference resources contained in any WebJar (such as javascript and css files) without specifying the version number. To do so, setup a <code>RequestMapping</code> like this:
+                <pre><code>@@ResponseBody
+@@RequestMapping("/webjarslocator/{webjar}/{partialPath:.+}")
+public ResponseEntity<Resource> locateWebjarAsset(@@PathVariable String webjar, @@PathVariable String partialPath) {
+    try {
+        String fullPath = assetLocator.getFullPath(webjar, partialPath);
+        return new ResponseEntity<Resource>(
+                new ClassPathResource(fullPath), HttpStatus.OK);
+    } catch (Exception e) {
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+}</code></pre>
+
+                Then, you can reference WebJar assets in your template like this:
+                <pre><code>&lt;link rel="stylesheet" href="/webjarslocator/jquery-mobile/jquery.mobile.structure.min.css" /&gt;
+&lt;script src="/webjarslocator/jquery/jquery.min.js"&gt;&lt;/script&gt;</code></pre>
+
                 <h3>Enhanced support for RequireJS</h3>
                 <a href="http://www.requirejs.org" target="_blank">RequireJS</a> is a popular implementation of the <a href="https://github.com/amdjs/amdjs-api/wiki/AMD">AMD</a>
                 specification - a means by which JavaScript applications can be modularised. The easiest way of thinking


### PR DESCRIPTION
This pull request includes two commits:
The first one 'Improved documentation for integrating RequireJS with webjars-locator' clarifies how to setup RequireJS properly. I would definitely suggest to apply this commit, because as it is right now, it is not very helpful to newbies.

The second one ('Spring MVC: Added section on how to utilize the webjar-locator') adds a new section that demonstrates how to load resources without needing to specify version numbers. I find this technique rather helpful, but it's really up to you whether you want this in there or not.

Hope this helps!

Kind regards,
Philipp