### PR TITLE
Added "BSD-3" to "BSD-3-Clause" license conversion.

### DIFF
--- a/app/utils/BinTray.scala
+++ b/app/utils/BinTray.scala
@@ -192,7 +192,8 @@ class BinTray(implicit ec: ExecutionContext, ws: WSAPI, config: Configuration) {
   val spdxToBinTrayLicenses = Map(
     "OFL-1.1" -> "Openfont-1.1",
     "Artistic-2.0" -> "Artistic-License-2.0",
-    "Apache 2" -> "Apache-2.0"
+    "Apache 2" -> "Apache-2.0",
+    "BSD-3" -> "BSD-3-Clause"
   )
 
   // from: https://bintray.com/docs/api/


### PR DESCRIPTION
This is required to get Bower bootstrap-fileinput:4.2.0 (github.com/kartik-v/bootstrap-fileinput) to deploy. Also added a newline to the end of the BinTray.scala file.