### PR TITLE
Fix the "BSD-3" license mapping again.

### DIFF
--- a/app/utils/BinTray.scala
+++ b/app/utils/BinTray.scala
@@ -193,7 +193,7 @@ class BinTray(implicit ec: ExecutionContext, ws: WSAPI, config: Configuration) {
     "OFL-1.1" -> "Openfont-1.1",
     "Artistic-2.0" -> "Artistic-License-2.0",
     "Apache 2" -> "Apache-2.0",
-    "BSD-3" -> "BSD-3-Clause"
+    "BSD-3" -> "BSD 3-Clause"
   )
 
   // from: https://bintray.com/docs/api/


### PR DESCRIPTION
BinTray licenses actually do not follow the SPDX License List.