### PR TITLE
Fall back to issues url when npm bugs is missing

### DIFF
--- a/app/utils/NPM.scala
+++ b/app/utils/NPM.scala
@@ -104,13 +104,16 @@ object NPM {
       .orElse((__ \ "licenses").read[Seq[JsObject]].map(_.map(_.\("type").as[String])))
       .orElse(Reads.pure(Seq.empty[String]))
 
+    val bugsReader = (__ \ "bugs" \ "url").read[String]
+      .orElse(sourceUrlReader.map(_ + "/issues"))
+
     (
       (__ \ "name").read[String] ~
       (__ \ "version").read[String] ~
       (__ \ "homepage").read[String].orElse(sourceUrlReader) ~
       sourceUrlReader ~
       sourceConnectionUrlReader ~
-      (__ \ "bugs" \ "url").read[String] ~
+      bugsReader ~
       licenseReader ~
       (__ \ "dependencies").read[Map[String, String]].orElse(Reads.pure(Map.empty[String, String]))
     )(PackageInfo.apply _)

--- a/test/utils/NPMSpec.scala
+++ b/test/utils/NPMSpec.scala
@@ -33,6 +33,11 @@ class NPMSpec extends PlaySpecification {
       await(npm.info("inherits", "2.0.1")).homepage must beEqualTo ("https://github.com/isaacs/inherits")
     }
   }
+  "simple-fmt" should {
+    "have a issue tracking url" in {
+      await(npm.info("simple-fmt", "0.1.0")).issuesUrl must beEqualTo ("https://github.com/olov/simple-fmt/issues")
+    }
+  }
 
   step(ws.close())
 


### PR DESCRIPTION
Similar to how it is done in the bower webjars.

Both GitHub and BitBucket have built-in issue trackers for any
repository available at repo-url.provider.com/issues.