### PR TITLE
Support for common mutation of GPL license

### DIFF
--- a/app/utils/BinTray.scala
+++ b/app/utils/BinTray.scala
@@ -193,7 +193,9 @@ class BinTray(implicit ec: ExecutionContext, ws: WSAPI, config: Configuration) {
     "OFL-1.1" -> "Openfont-1.1",
     "Artistic-2.0" -> "Artistic-License-2.0",
     "Apache 2" -> "Apache-2.0",
-    "BSD-3" -> "BSD 3-Clause"
+    "BSD-3" -> "BSD 3-Clause",
+    "GPLv2" -> "GPL-2.0",
+    "GPLv3" -> "GPL-3.0"
   )
 
   // from: https://bintray.com/docs/api/

--- a/test/utils/BinTraySpec.scala
+++ b/test/utils/BinTraySpec.scala
@@ -36,12 +36,14 @@ class BinTraySpec extends PlaySpecification {
       (result \ "message").asOpt[String] must beSome ("success")
     }
     "convert licenses to accepted ones" in {
-      val licenses = Seq("BSD 2-Clause", "BSD-2-Clause", "bsd2clause")
+      val licenses = Seq("BSD 2-Clause", "BSD-2-Clause", "bsd2clause", "GPLv2", "GPLv3")
       val result = await(binTray.convertLicenses(licenses))
-      result.size must be equalTo 3
+      result.size must be equalTo 5
       result(0) must be equalTo "BSD 2-Clause"
       result(1) must be equalTo "BSD 2-Clause"
       result(2) must be equalTo "BSD 2-Clause"
+      result(3) must be equalTo "GPL-2.0"
+      result(3) must be equalTo "GPL-3.0"
     }
     "convert SPDX to BinTray" in {
       val licenses = Seq("OFL-1.1")


### PR DESCRIPTION
GPLv2/3 is not SPDX formatted, but used in various (mostly older) node packages.