### PR TITLE
Additional package conversions

### DIFF
--- a/app/utils/BinTray.scala
+++ b/app/utils/BinTray.scala
@@ -195,7 +195,8 @@ class BinTray(implicit ec: ExecutionContext, ws: WSAPI, config: Configuration) {
     "Apache 2" -> "Apache-2.0",
     "BSD-3" -> "BSD 3-Clause",
     "GPLv2" -> "GPL-2.0",
-    "GPLv3" -> "GPL-3.0"
+    "GPLv3" -> "GPL-3.0",
+    "MIT/X11" -> "MIT"
   )
 
   // from: https://bintray.com/docs/api/

--- a/test/utils/BinTraySpec.scala
+++ b/test/utils/BinTraySpec.scala
@@ -36,14 +36,15 @@ class BinTraySpec extends PlaySpecification {
       (result \ "message").asOpt[String] must beSome ("success")
     }
     "convert licenses to accepted ones" in {
-      val licenses = Seq("BSD 2-Clause", "BSD-2-Clause", "bsd2clause", "GPLv2", "GPLv3")
+      val licenses = Seq("BSD 2-Clause", "BSD-2-Clause", "bsd2clause", "GPLv2", "GPLv3", "MIT/X11")
       val result = await(binTray.convertLicenses(licenses))
-      result.size must be equalTo 5
+      result.size must be equalTo 6
       result(0) must be equalTo "BSD 2-Clause"
       result(1) must be equalTo "BSD 2-Clause"
       result(2) must be equalTo "BSD 2-Clause"
       result(3) must be equalTo "GPL-2.0"
       result(4) must be equalTo "GPL-3.0"
+      result(5) must be equalTo "MIT"
     }
     "convert SPDX to BinTray" in {
       val licenses = Seq("OFL-1.1")


### PR DESCRIPTION
Running in to more repositories using 'MIT/X11' as the license. Adding a
mapping for this license type to just 'MIT' as BinTray expects.