### PR TITLE
Updated Spring related documentation.

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -370,8 +370,54 @@ public class MainService extends Service<Configuration> {
                 <br>
                 Then reference a WebJar asset like:
                 <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/3.1.0/css/bootstrap.min.css'&gt;</code></pre>
+                
+                <h4>Making dependencies version agnostic</h4>
+                
+                When using Spring Boot version 1.3 or higher, it will automatically detect the <code>webjars-locator</code> library on the classpath and use it to automatically resolve the version of any WebJar assets for you.
+                In order to enable this feature, you will need to add the webjars-locator library as a dependency of your application in the <span class="label label-info">pom.xml</span> file, like:
+                <pre><code>&lt;dependencies&gt;
+    &lt;dependency&gt;
+        &lt;groupId&gt;org.webjars&lt;/groupId&gt;
+        &lt;artifactId&gt;webjars-locator&lt;/artifactId&gt;
+        &lt;version&gt;0.30&lt;/version&gt;
+    &lt;/dependency&gt;
+&lt;/dependencies&gt;</code></pre>
+                <br>
+                Then you may reference a WebJar asset in your template like this:
+                <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/css/bootstrap.min.css'&gt;</code></pre>
+                <br>
+                <div class="alert alert-danger" role="alert">Be sure to remove <strong>ONLY</strong> the version from the path, otherwise relative imports may not work.</div>
                 <br>
                 <div class="alert alert-danger" role="alert">Following the Spring MVC instructions in a Spring Boot project will result in disabling the static content mapping configured by Spring Boot.</div>
+
+                <h4>Enhanced support for RequireJS</h4>
+                <a href="http://www.requirejs.org" target="_blank">RequireJS</a> is a popular implementation of the <a href="https://github.com/amdjs/amdjs-api/wiki/AMD">AMD</a>
+                specification - a means by which JavaScript applications can be modularised. The easiest way of thinking
+                about AMD is that it is JavaScript's equivalent of package and import statements (or namespace and
+                include statements depending on your preferences!). These instructions assume basic knowledge of
+                RequireJS.
+                
+                <br><br>
+                
+                The <span class="label label-info">webjars-locator</span> library has built-in support for RequireJS.  To setup RequireJS use the <code>webjars-locator</code> library like this:
+                <pre><code>@@ResponseBody
+@@RequestMapping(value = "/webjarsjs", produces = "application/javascript")
+public String webjarjs() {
+    return RequireJS.getSetupJavaScript("/webjars/");
+}</code></pre>
+
+                <span class="label label-success">Note</span> The <code>RequestMapping</code> must not be the same as given to the <code>ResourceHandler</code>
+                <br>
+                <span class="label label-success">Note</span> The url given to <code>getSetupJavaScript</code> has to be the url given to <code>ResourceHandler</code> and end with a <span>/</span>
+                <br><br>
+                This <code>RequestMapping</code> returns the setup code for your webjars and requirejs. It has to be included in your template before loading RequireJS. A basic setup looks like this:
+                <pre><code>&lt;script src="/webjarsjs"&gt;&lt;/script&gt;
+&lt;script data-main="/js/app" src="/webjars/requirejs/require.min.js"&gt;&lt;/script&gt;</code></pre>
+                This loads the WebJars RequireJS configuration from <span class="label label-info">webjars-locator</span> and the RequireJS with a main JavaScript of <span class="label label-info">js/app</span>.
+                <br><br>
+                Underneath the covers each WebJar can have a RequireJS configuration file that sets up the modules, shims, exports, etc.  These files is named <span class="label label-info">webjars-requirejs.js</span> and are automatically added to the page via the <code>RequireJS.setup</code> helper.
+                
+                Some of the WebJars may not be updated to the new WebJars RequireJS syntax so if you experience problems please file issues on the WebJars you are using.
             </div>
 
             <!-- Spring MVC -->
@@ -416,27 +462,24 @@ public class WebConfig extends WebMvcConfigurerAdapter {
                 Then reference a WebJar asset like: 
                 <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/3.1.0/css/bootstrap.min.css'&gt;</code></pre>
                 
-                <h3>Making dependencies version agnostic</h3>
-                By utilizing the <code>webjars-locator</code> library, it is possible to reference resources contained in any WebJar (such as javascript and css files) without specifying the version number. To do so, setup a <code>RequestMapping</code> like this:
-                <pre><code>@@ResponseBody
-@@RequestMapping("/webjarslocator/{webjar}/**")
-public ResponseEntity<Resource> locateWebjarAsset(@@PathVariable String webjar, HttpServletRequest request) {
-    try {
-    	String mvcPrefix = "/webjarslocator/" + webjar + "/"; // This prefix must match the mapping path!
-    	String mvcPath = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-        String fullPath = assetLocator.getFullPath(webjar, mvcPath.substring(mvcPrefix.length()));
-        return new ResponseEntity<Resource>(new ClassPathResource(fullPath), HttpStatus.OK);
-    } catch (Exception e) {
-        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
-}</code></pre>
-
-                Then you may reference a WebJar asset in your template like this:
-                <pre><code>&lt;link rel='stylesheet' href='/webjarslocator/bootstrap/css/bootstrap.min.css'&gt;</code></pre>
+                <h4>Making dependencies version agnostic</h4>
                 
+                When using Spring Framework version 4.2 or higher, it will automatically detect the <code>webjars-locator</code> library on the classpath and use it to automatically resolve the version of any WebJar assets for you.
+                In order to enable this feature, you will need to add the webjars-locator library as a dependency of your application in the <span class="label label-info">pom.xml</span> file, like:
+                <pre><code>&lt;dependencies&gt;
+    &lt;dependency&gt;
+        &lt;groupId&gt;org.webjars&lt;/groupId&gt;
+        &lt;artifactId&gt;webjars-locator&lt;/artifactId&gt;
+        &lt;version&gt;0.30&lt;/version&gt;
+    &lt;/dependency&gt;
+&lt;/dependencies&gt;</code></pre>
+                <br>
+                Then you may reference a WebJar asset in your template like this:
+                <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/css/bootstrap.min.css'&gt;</code></pre>
+                <br>
                 <div class="alert alert-danger" role="alert">Be sure to remove <strong>ONLY</strong> the version from the path, otherwise relative imports may not work.</div>
 
-                <h3>Enhanced support for RequireJS</h3>
+                <h4>Enhanced support for RequireJS</h4>
                 <a href="http://www.requirejs.org" target="_blank">RequireJS</a> is a popular implementation of the <a href="https://github.com/amdjs/amdjs-api/wiki/AMD">AMD</a>
                 specification - a means by which JavaScript applications can be modularised. The easiest way of thinking
                 about AMD is that it is JavaScript's equivalent of package and import statements (or namespace and
@@ -458,7 +501,7 @@ public String webjarjs() {
                 <br><br>
                 This <code>RequestMapping</code> returns the setup code for your webjars and requirejs. It has to be included in your template before loading RequireJS. A basic setup looks like this:
                 <pre><code>&lt;script src="/webjarsjs"&gt;&lt;/script&gt;
-&lt;script data-main="/js/app" src="/webjars/requirejs/2.1.16/require.min.js"&gt;&lt;/script&gt;</code></pre>
+&lt;script data-main="/js/app" src="/webjars/requirejs/require.min.js"&gt;&lt;/script&gt;</code></pre>
                 This loads the WebJars RequireJS configuration from <span class="label label-info">webjars-locator</span> and the RequireJS with a main JavaScript of <span class="label label-info">js/app</span>.
                 <br><br>
                 Underneath the covers each WebJar can have a RequireJS configuration file that sets up the modules, shims, exports, etc.  These files is named <span class="label label-info">webjars-requirejs.js</span> and are automatically added to the page via the <code>RequireJS.setup</code> helper.


### PR DESCRIPTION
Hi there,

with Spring Framework version 4.2 and Spring Boot version 1.3, the support for WebJars has been greatly improved and it now automatically detects the webjars-locator library on the classpath, if available. When it is detected, it is automatically used to resolve the version for WebJar assets, which is quite neat.

Basically this supersedes the previous instructions in the documentation that detailed how to manually add a request mapping for this job.

In addition, I have added the relevant parts to the Spring Boot section as well.

Hope that helps!

Kind regards,
Philipp