### PR TITLE
Restructuring nav links for better mobile experience

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -36,18 +36,26 @@
         <nav class="navbar navbar-inverse navbar-fixed-top">
             <div class="container-fluid">
                 <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-nav-links" aria-expanded="false">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
                     <a class="navbar-brand" style="padding-top: 10px" href="@routes.Application.index()">
                         <img alt="WebJars" src="@routes.Assets.at("logo.png")" height="30">
                     </a>
                     <a class="navbar-brand @if(title.indexOf("Web Libraries in Jars") > -1) { active }" href="@routes.Application.index()">WebJars</a>
+                </div>
+                <div class="collapse navbar-collapse" id="main-nav-links">
                     <ul class="nav navbar-nav">
                         <li @if(title.toLowerCase.indexOf("doc") > -1) { class="active" }><a href="@routes.Application.documentation()">Documentation</a></li>
                         <li @if(title.toLowerCase.indexOf("npm") > -1) { class="active" }><a href="@routes.Application.npmList()">NPM WebJars</a></li>
                         <li @if(title.toLowerCase.indexOf("bower") > -1) { class="active" }><a href="@routes.Application.bowerList()">Bower WebJars</a></li>
                         <li @if(title.toLowerCase.indexOf("classic") > -1) { class="active" }><a href="@routes.Application.classicList()">Classic WebJars</a></li>
                     </ul>
+                    <p class="navbar-text navbar-right" style="margin-right: 4px">Sponsored by <a href="http://bintray.com" class="navbar-link">BinTray</a> &amp; <a href="http://heroku.com" class="navbar-link">Heroku</a></p>
                 </div>
-                <p class="navbar-text navbar-right" style="margin-right: 4px">Sponsored by <a href="http://bintray.com" class="navbar-link">BinTray</a> &amp; <a href="http://heroku.com" class="navbar-link">Heroku</a></p>
             </div>
         </nav>
 


### PR DESCRIPTION
Right now on http://www.webjars.org/ if you view it on a mobile device, you'll see:

<img src="https://cloud.githubusercontent.com/assets/4752550/14937684/4a1fc804-0edd-11e6-9229-04c209df788f.png" height="300px"/>

Where the menu will cover up some important buttons, making the site mostly unusable.

I restructured the nav links so that they will collapse under a dropdown menu when on mobile:

<img src="https://cloud.githubusercontent.com/assets/4752550/14937704/c15434fa-0edd-11e6-8ce4-97e3b843bb3b.png" height="300px"/>
and
<img src="https://cloud.githubusercontent.com/assets/4752550/14937705/d771bc12-0edd-11e6-8d59-b008cfd2966b.png" height="300px"/>