### PR TITLE
Github Webjars publish

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -27,8 +27,8 @@
             All of the WebJar contents are available on the public <a href="http://www.jsdelivr.com" target="_blank">jsDelivr</a> CDN.
             Just prefix <code>//cdn.jsdelivr.net/webjars/{groupId}</code> in front of your static asset URLs.  For instance, if using the <code>org.webjars : jquery</code> WebJar and your local URL to <code>jquery.js</code> is <code>/webjars/jquery/2.1.0/jquery.js</code> then the CDN URL would be: <code>//cdn.jsdelivr.net/webjars/org.webjars/jquery/2.1.0/jquery.js</code>
             <h4 style="padding-top: 15px;">Adding new bower webjar</h4>
-            The webjar could be added directly from bower or using the github repository with bower settings. In the second case the
-            webjar name is generated using the github path. That resolves a dependency problem when some of the webjars are looking for webjars with such names.
+            The webjar could be added directly from bower or using the github repository url with bower settings. In the second case the
+            webjar name is generated using the github url. That resolves a dependency problem when some of the webjars are looking for webjars with such names.
         </div>
     </div>
 

--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -26,6 +26,9 @@
             <h4 style="padding-top: 15px;">Public CDN via <a href="http://www.jsdelivr.com" target="_blank">jsDelivr</a></h4>
             All of the WebJar contents are available on the public <a href="http://www.jsdelivr.com" target="_blank">jsDelivr</a> CDN.
             Just prefix <code>//cdn.jsdelivr.net/webjars/{groupId}</code> in front of your static asset URLs.  For instance, if using the <code>org.webjars : jquery</code> WebJar and your local URL to <code>jquery.js</code> is <code>/webjars/jquery/2.1.0/jquery.js</code> then the CDN URL would be: <code>//cdn.jsdelivr.net/webjars/org.webjars/jquery/2.1.0/jquery.js</code>
+            <h4 style="padding-top: 15px;">Adding new bower webjar</h4>
+            The webjar could be added directly from bower or using the github repository with bower settings. In the second case the
+            webjar name is generated using the github path. That resolves a dependency problem when some of the webjars are looking for webjars with such names.
         </div>
     </div>
 


### PR DESCRIPTION
Improve the documentation to include the information about publishing bower webjars using the github url.