### PR TITLE
refactor filtering for faster rendering

### DIFF
--- a/app/assets/javascripts/webJarList.js
+++ b/app/assets/javascripts/webJarList.js
@@ -32,25 +32,17 @@ $(function() {
   $("#clearSearch").click(function(){
     $("#search").val("");
     $(this).hide();
-    filterWebJars();
+    filterWebJars("");
   });
 
 });
 
 function filterWebJars(search) {
-  if (!search) {
-    $("tr[data-artifact]").show();
-  }
-  else {
-    $("tr[data-artifact]").each(function() {
-      if ($(this).data("artifact").toLowerCase().indexOf(search.toLowerCase()) == -1) {
-        $(this).hide();
-      }
-      else {
-        $(this).show()
-      }
-    });
-  }
+  $("tr[data-artifact]").each(function() {
+    var row = $(this);
+    var shouldHide = row.data("artifact").toLowerCase().indexOf(search.toLowerCase()) === -1;
+    row.toggleClass('hide', shouldHide);
+  });
 }
 
 function onFileList(event) {


### PR DESCRIPTION
Here are 2 timelines with the before (bigger file) and after for the search "modelico". Summarizing, the before shows ~4 s of scripting and ~16 s of rendering, while the after shows ~0.3 s of scripting and ~0.4 s  rendering.

[timelines.zip](https://github.com/webjars/webjars/files/618968/timelines.zip)