### PR TITLE
Fix syntax error "Syntax error, unrecognized expression: input[name='search_catalog[]"

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -172,7 +172,7 @@ $(function() {
     }
   });
 
-  $("input[name='search_catalog[]'").change(function() {
+  $("input[name='search_catalog[]']").change(function() {
     handleSearch();
   });
 

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -172,7 +172,7 @@ $(function() {
     }
   });
 
-  $("input[name='search_catalog[]").change(function() {
+  $("input[name='search_catalog[]'").change(function() {
     handleSearch();
   });
 


### PR DESCRIPTION
Adds a missing ']