### PR TITLE
Update Spring Boot section to more recent versions

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -367,22 +367,22 @@ public class MainService extends Service<Configuration> {
 
                 <h4>Making dependencies version agnostic</h4>
 
-                When using Spring Boot version 1.3 or higher, it will automatically detect the <code>webjars-locator</code> library on the classpath and use it to automatically resolve the version of any WebJar assets for you.
-                In order to enable this feature, you will need to add the webjars-locator library as a dependency of your application in the <span class="label label-info">pom.xml</span> file, like:
+                When using Spring Boot, it will automatically detect the <code>webjars-locator-core</code> library on the classpath and use it to automatically resolve the version of any WebJar assets for you.
+                In order to enable this feature, you will need to add the webjars-locator-core library as a dependency of your application in the <span class="label label-info">pom.xml</span> file, like:
                 <pre><code>&lt;dependencies&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.webjars&lt;/groupId&gt;
-        &lt;artifactId&gt;webjars-locator&lt;/artifactId&gt;
-        &lt;version&gt;0.30&lt;/version&gt;
+        &lt;artifactId&gt;webjars-locator-core&lt;/artifactId&gt;
+        &lt;version&gt;0.48&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;</code></pre>
                 <br>
-                Then you may reference a WebJar asset in your template like this:
+                (Spring Boot manages the version if you use its BOM feature.) Then you may reference a WebJar asset in your template like this:
                 <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/css/bootstrap.min.css'&gt;</code></pre>
                 <br>
                 <div class="alert alert-danger" role="alert">Be sure to remove <strong>ONLY</strong> the version from the path, otherwise relative imports may not work.</div>
                 <br>
-                <div class="alert alert-danger" role="alert">Following the Spring MVC instructions in a Spring Boot project will result in disabling the static content mapping configured by Spring Boot.</div>
+                <div class="alert alert-danger" role="alert">Customising the web layer with `@EnableWebMcv` or `@EnableWebFlux` will result in disabling the static content mapping configured by Spring Boot, including the webjars handling. There are usually other extension points that you can use instead.</div>
 
                 <h4>Enhanced support for RequireJS</h4>
                 <a href="http://www.requirejs.org" target="_blank">RequireJS</a> is a popular implementation of the <a href="https://github.com/amdjs/amdjs-api/wiki/AMD">AMD</a>


### PR DESCRIPTION
Spring Boot looks for the "core" library and only needs that. Also the version was old in the example.