### PR TITLE
docs: Include WebJarsResourceResolver Spring Framework 4.2

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -498,8 +498,8 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     &lt;mvc:resource-chain resource-cache="true"/&gt;
 &lt;/mvc:resources&gt;</code></pre>
                 <br>
-                Or in case of Java config add the resourceChain() method:
-                <pre><code>registry.addResourceHandler("/webjars/**").addResourceLocations("/webjars/").setCachePeriod(CACHE_PERIOD).resourceChain(true);</code></pre>
+                Or in case of Java config add the resourceChain() method and the WebJarsResourceResolver:
+                <pre><code>registry.addResourceHandler("/webjars/**").addResourceLocations("/webjars/").setCachePeriod(CACHE_PERIOD).resourceChain(true).addResolver(new WebJarsResourceResolver());</code></pre>
                 <br>
                 Then you may reference a WebJar asset in your template like this:
                 <pre><code>&lt;link rel='stylesheet' href='/webjars/bootstrap/css/bootstrap.min.css'&gt;</code></pre>


### PR DESCRIPTION
I just tried to run a Spring Boot 3.1.2 (Spring MVC 6.0.11) app with WebMvc enabled (`@EnableWebMvc`) and the version agnostic dependency resolvement.

The current documentation did not work for me (anymore). Adding the `WebJarsResourceResolver` solved it. It is available since Spring MVC 4.2, see https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/resource/WebJarsResourceResolver.html

I don't know if it's also configurable via xml.