### PR TITLE
doc(spring-boot): use webjars-locator-lite

### DIFF
--- a/app/views/documentation.scala.html
+++ b/app/views/documentation.scala.html
@@ -397,8 +397,8 @@ public class MainService extends Service<Configuration> {
                 <pre><code>&lt;dependencies&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.webjars&lt;/groupId&gt;
-        &lt;artifactId&gt;webjars-locator-core&lt;/artifactId&gt;
-        &lt;version&gt;0.48&lt;/version&gt;
+        &lt;artifactId&gt;webjars-locator-lite&lt;/artifactId&gt;
+        &lt;version&gt;1.1.0&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;</code></pre>
                 <br>


### PR DESCRIPTION
This is what is recommended by SpringBoot since v3.4 and support of `webjars-locator-core` is deprecated, see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes#webjars-locator-integration